### PR TITLE
Camera adjustments and substantial resolution changes.

### DIFF
--- a/src/SS.Core/GUISystem/Events/SGUIEvents.Mouse.cs
+++ b/src/SS.Core/GUISystem/Events/SGUIEvents.Mouse.cs
@@ -14,7 +14,7 @@ namespace StardustSandbox.Core.GUISystem.Events
         /// </summary>
         public bool OnMouseClick(Vector2 targetPosition, SSize2 areaSize)
         {
-            Vector2 mousePosition = this._inputManager.MouseState.Position.ToVector2();
+            Vector2 mousePosition = this._inputManager.GetScaledMousePosition();
 
             return this._inputManager.MouseState.LeftButton == ButtonState.Released &&
                    this._inputManager.PreviousMouseState.LeftButton == ButtonState.Pressed &&
@@ -26,7 +26,7 @@ namespace StardustSandbox.Core.GUISystem.Events
         /// </summary>
         public bool OnMouseDown(Vector2 targetPosition, SSize2 areaSize)
         {
-            Vector2 mousePosition = this._inputManager.MouseState.Position.ToVector2();
+            Vector2 mousePosition = this._inputManager.GetScaledMousePosition();
 
             return this._inputManager.MouseState.LeftButton == ButtonState.Pressed &&
                    IsMouseWithinArea(mousePosition, targetPosition, areaSize);
@@ -37,7 +37,7 @@ namespace StardustSandbox.Core.GUISystem.Events
         /// </summary>
         public bool OnMouseUp(Vector2 targetPosition, SSize2 areaSize)
         {
-            Vector2 mousePosition = this._inputManager.MouseState.Position.ToVector2();
+            Vector2 mousePosition = this._inputManager.GetScaledMousePosition();
 
             return this._inputManager.MouseState.LeftButton == ButtonState.Released &&
                    this._inputManager.PreviousMouseState.LeftButton == ButtonState.Pressed &&
@@ -49,8 +49,8 @@ namespace StardustSandbox.Core.GUISystem.Events
         /// </summary>
         public bool OnMouseEnter(Vector2 targetPosition, SSize2 areaSize)
         {
-            Vector2 mousePosition = this._inputManager.MouseState.Position.ToVector2();
-            Vector2 previousMousePosition = this._inputManager.PreviousMouseState.Position.ToVector2();
+            Vector2 mousePosition = this._inputManager.GetScaledMousePosition();
+            Vector2 previousMousePosition = this._inputManager.GetScaledPreviousMousePosition();
 
             bool mouseWasOutside = !IsMouseWithinArea(previousMousePosition, targetPosition, areaSize);
             bool mouseIsInside = IsMouseWithinArea(mousePosition, targetPosition, areaSize);
@@ -63,7 +63,7 @@ namespace StardustSandbox.Core.GUISystem.Events
         /// </summary>
         public bool OnMouseOver(Vector2 targetPosition, SSize2 areaSize)
         {
-            Vector2 mousePosition = this._inputManager.MouseState.Position.ToVector2();
+            Vector2 mousePosition = this._inputManager.GetScaledMousePosition();
 
             return IsMouseWithinArea(mousePosition, targetPosition, areaSize);
         }
@@ -73,8 +73,8 @@ namespace StardustSandbox.Core.GUISystem.Events
         /// </summary>
         public bool OnMouseLeave(Vector2 targetPosition, SSize2 areaSize)
         {
-            Vector2 mousePosition = this._inputManager.MouseState.Position.ToVector2();
-            Vector2 previousMousePosition = this._inputManager.PreviousMouseState.Position.ToVector2();
+            Vector2 mousePosition = this._inputManager.GetScaledMousePosition();
+            Vector2 previousMousePosition = this._inputManager.GetScaledPreviousMousePosition();
 
             bool mouseWasInside = IsMouseWithinArea(previousMousePosition, targetPosition, areaSize);
             bool mouseIsOutside = !IsMouseWithinArea(mousePosition, targetPosition, areaSize);

--- a/src/SS.Core/Interfaces/General/ISGame.cs
+++ b/src/SS.Core/Interfaces/General/ISGame.cs
@@ -17,6 +17,7 @@ namespace StardustSandbox.Core.Interfaces.General
         SInputManager InputManager { get; }
         SGameInputManager GameInputManager { get; }
         SCameraManager CameraManager { get; }
+        SGraphicsManager GraphicsManager { get; }
         SGUIManager GUIManager { get; }
 
         // Core

--- a/src/SS.Core/Managers/SCameraManager.cs
+++ b/src/SS.Core/Managers/SCameraManager.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
-using StardustSandbox.Core.Constants;
 using StardustSandbox.Core.Mathematics.Primitives;
 
 using System;
@@ -13,7 +12,6 @@ namespace StardustSandbox.Core.Managers
         public Vector2 Position { get; set; }
         public float Rotation { get; set; }
         public Vector2 Origin { get; set; }
-        public Vector2 Center => this.Position + this.Origin;
         public float Zoom
         {
             get => this._zoom;
@@ -110,16 +108,6 @@ namespace StardustSandbox.Core.Managers
             this.Zoom = value < this.MinimumZoom ? this.MinimumZoom : value > this.MaximumZoom ? this.MaximumZoom : value;
         }
 
-        public void LookAt(Vector2 position)
-        {
-            this.Position = position - (new Vector2(SScreenConstants.DEFAULT_SCREEN_WIDTH, SScreenConstants.DEFAULT_SCREEN_HEIGHT) / 2f);
-        }
-
-        public Vector2 WorldToScreen(float x, float y)
-        {
-            return WorldToScreen(new Vector2(x, y));
-        }
-
         public Vector2 WorldToScreen(Vector2 worldPosition)
         {
             Viewport viewport = this._graphicsManager.Viewport;
@@ -129,8 +117,7 @@ namespace StardustSandbox.Core.Managers
         public Vector2 ScreenToWorld(Vector2 screenPosition)
         {
             Viewport viewport = this._graphicsManager.Viewport;
-            return Vector2.Transform(screenPosition - new Vector2(viewport.X, viewport.Y),
-                   Matrix.Invert(GetViewMatrix()));
+            return Vector2.Transform(screenPosition - new Vector2(viewport.X, viewport.Y), Matrix.Invert(GetViewMatrix()));
         }
 
         private Matrix GetVirtualViewMatrix()

--- a/src/SS.Core/Managers/SCameraManager.cs
+++ b/src/SS.Core/Managers/SCameraManager.cs
@@ -98,11 +98,6 @@ namespace StardustSandbox.Core.Managers
             ClampZoom(this.Zoom - deltaZoom);
         }
 
-        public void ClampPosition(Vector2 min, Vector2 max)
-        {
-            _ = Vector2.Clamp(this.Position, min, max);
-        }
-
         public void ClampZoom(float value)
         {
             this.Zoom = value < this.MinimumZoom ? this.MinimumZoom : value > this.MaximumZoom ? this.MaximumZoom : value;

--- a/src/SS.Core/Managers/SCameraManager.cs
+++ b/src/SS.Core/Managers/SCameraManager.cs
@@ -120,6 +120,11 @@ namespace StardustSandbox.Core.Managers
             return Vector2.Transform(screenPosition - new Vector2(viewport.X, viewport.Y), Matrix.Invert(GetViewMatrix()));
         }
 
+        public Matrix GetViewMatrix()
+        {
+            return GetVirtualViewMatrix() * Matrix.Identity;
+        }
+
         private Matrix GetVirtualViewMatrix()
         {
             return Matrix.CreateTranslation(new(-this.Position.X, this.Position.Y, 0.0f)) *
@@ -127,11 +132,6 @@ namespace StardustSandbox.Core.Managers
                    Matrix.CreateRotationZ(this.Rotation) *
                    Matrix.CreateScale(this.Zoom, this.Zoom, 1) *
                    Matrix.CreateTranslation(new(this.Origin, 0.0f));
-        }
-
-        public Matrix GetViewMatrix()
-        {
-            return GetVirtualViewMatrix() * Matrix.Identity;
         }
 
         public bool InsideCameraBounds(Vector2 targetPosition, SSize2 targetSize, bool inWorldPosition, float toleranceFactor = 0f)

--- a/src/SS.Core/Managers/SGameInputManager.Controllers.cs
+++ b/src/SS.Core/Managers/SGameInputManager.Controllers.cs
@@ -123,7 +123,7 @@ namespace StardustSandbox.Core.Managers
         #region ELEMENTS
         private void PutElementsInWorld(ISElement element)
         {
-            Point worldPos = GetWorldPositionFromMouse().ToPoint();
+            Point worldPos = GetWorldGridPositionFromMouse();
 
             if (!IsValidWorldPosition(worldPos))
             {
@@ -140,7 +140,7 @@ namespace StardustSandbox.Core.Managers
         }
         private void RemoveElementsFromWorld()
         {
-            Point worldPos = GetWorldPositionFromMouse().ToPoint();
+            Point worldPos = GetWorldGridPositionFromMouse();
 
             if (!IsValidWorldPosition(worldPos))
             {
@@ -178,10 +178,38 @@ namespace StardustSandbox.Core.Managers
 
         // ================================== //
         // Utilities
-        private Vector2 GetWorldPositionFromMouse()
+        private Point GetWorldGridPositionFromMouse()
         {
-            Vector2 screenPos = this._cameraManager.ScreenToWorld(this._inputManager.MouseState.Position.ToVector2());
-            return new Vector2(screenPos.X, screenPos.Y) / SWorldConstants.GRID_SCALE;
+            Vector2 mousePosition = GetMousePositionInScreenSpace();
+            Vector2 worldPosition = ConvertScreenToWorld(mousePosition);
+            Vector2 gridPosition = SnapToGrid(worldPosition);
+
+            return gridPosition.ToPoint();
+        }
+
+        private Vector2 GetMousePositionInScreenSpace()
+        {
+            return this._inputManager.GetScaledMousePosition();
+        }
+
+        private Vector2 ConvertScreenToWorld(Vector2 screenPosition)
+        {
+            Vector3 screenPosition3D = new(screenPosition, 0);
+
+            Matrix viewMatrix = this._cameraManager.GetViewMatrix();
+            Matrix inverseViewMatrix = Matrix.Invert(viewMatrix);
+
+            Vector3 worldPosition3D = Vector3.Transform(screenPosition3D, inverseViewMatrix);
+
+            return new Vector2(worldPosition3D.X, worldPosition3D.Y);
+        }
+
+        private static Vector2 SnapToGrid(Vector2 worldPosition)
+        {
+            return new Vector2(
+                (int)(worldPosition.X / SWorldConstants.GRID_SCALE),
+                (int)(worldPosition.Y / SWorldConstants.GRID_SCALE)
+            );
         }
     }
 }

--- a/src/SS.Core/Managers/SGameInputManager.Controllers.cs
+++ b/src/SS.Core/Managers/SGameInputManager.Controllers.cs
@@ -24,6 +24,8 @@ namespace StardustSandbox.Core.Managers
             worldKeyboardActionMap.AddAction("World_Camera_Right", new SInputAction(this.SGameInstance, this._inputManager, Keys.D, Keys.Right)).OnPerformed += _ => MoveCamera(SCardinalDirection.East);
             worldKeyboardActionMap.AddAction("World_Camera_Down", new SInputAction(this.SGameInstance, this._inputManager, Keys.S, Keys.Down)).OnPerformed += _ => MoveCamera(SCardinalDirection.South);
             worldKeyboardActionMap.AddAction("World_Camera_Left", new SInputAction(this.SGameInstance, this._inputManager, Keys.A, Keys.Left)).OnPerformed += _ => MoveCamera(SCardinalDirection.West);
+            worldKeyboardActionMap.AddAction("World_Camera_Zoom_In", new SInputAction(this.SGameInstance, this._inputManager, Keys.OemPlus)).OnPerformed += _ => CameraZoomIn();
+            worldKeyboardActionMap.AddAction("World_Camera_Zoom_Out", new SInputAction(this.SGameInstance, this._inputManager, Keys.OemMinus)).OnPerformed += _ => CameraZoomOut();
 
             // Shortcuts
             worldKeyboardActionMap.AddAction("World_Pause", new(this.SGameInstance, this._inputManager, Keys.Space)).OnStarted += _ => PauseWorld();
@@ -62,6 +64,16 @@ namespace StardustSandbox.Core.Managers
                 default:
                     return;
             }
+        }
+
+        private void CameraZoomIn()
+        {
+            this._cameraManager.ZoomIn(0.005f);
+        }
+
+        private void CameraZoomOut()
+        {
+            this._cameraManager.ZoomOut(0.005f);
         }
 
         // ================================== //

--- a/src/SS.Core/Managers/SGameInputManager.Controllers.cs
+++ b/src/SS.Core/Managers/SGameInputManager.Controllers.cs
@@ -24,8 +24,6 @@ namespace StardustSandbox.Core.Managers
             worldKeyboardActionMap.AddAction("World_Camera_Right", new SInputAction(this.SGameInstance, this._inputManager, Keys.D, Keys.Right)).OnPerformed += _ => MoveCamera(SCardinalDirection.East);
             worldKeyboardActionMap.AddAction("World_Camera_Down", new SInputAction(this.SGameInstance, this._inputManager, Keys.S, Keys.Down)).OnPerformed += _ => MoveCamera(SCardinalDirection.South);
             worldKeyboardActionMap.AddAction("World_Camera_Left", new SInputAction(this.SGameInstance, this._inputManager, Keys.A, Keys.Left)).OnPerformed += _ => MoveCamera(SCardinalDirection.West);
-            worldKeyboardActionMap.AddAction("World_Camera_Zoom_In", new SInputAction(this.SGameInstance, this._inputManager, Keys.OemPlus)).OnPerformed += _ => CameraZoomIn();
-            worldKeyboardActionMap.AddAction("World_Camera_Zoom_Out", new SInputAction(this.SGameInstance, this._inputManager, Keys.OemMinus)).OnPerformed += _ => CameraZoomOut();
 
             // Shortcuts
             worldKeyboardActionMap.AddAction("World_Pause", new(this.SGameInstance, this._inputManager, Keys.Space)).OnStarted += _ => PauseWorld();
@@ -64,16 +62,6 @@ namespace StardustSandbox.Core.Managers
                 default:
                     return;
             }
-        }
-
-        private void CameraZoomIn()
-        {
-            this._cameraManager.ZoomIn(0.005f);
-        }
-
-        private void CameraZoomOut()
-        {
-            this._cameraManager.ZoomOut(0.005f);
         }
 
         // ================================== //

--- a/src/SS.Core/Managers/SGameInputManager.cs
+++ b/src/SS.Core/Managers/SGameInputManager.cs
@@ -48,8 +48,8 @@ namespace StardustSandbox.Core.Managers
             UpdatePlaceAreaSize();
             this._actionHandler.Update(gameTime);
 
-            // External
-            ClampCamera();
+            // Camera
+            ClampCameraInTheWorld();
         }
 
         // Update
@@ -82,12 +82,26 @@ namespace StardustSandbox.Core.Managers
         }
 
         // Utilities
-        private void ClampCamera()
+        private void ClampCameraInTheWorld()
         {
-            int totalX = (int)(this._world.Infos.Size.Width * SWorldConstants.GRID_SCALE) - SScreenConstants.DEFAULT_SCREEN_WIDTH;
-            int totalY = (int)(this._world.Infos.Size.Height * SWorldConstants.GRID_SCALE) - SScreenConstants.DEFAULT_SCREEN_HEIGHT;
+            int totalWorldWidth = (int)(this._world.Infos.Size.Width * SWorldConstants.GRID_SCALE);
+            int totalWorldHeight = (int)(this._world.Infos.Size.Height * SWorldConstants.GRID_SCALE);
 
-            this._cameraManager.ClampPosition(new Vector2(0, -totalY), new Vector2(totalX, 0));
+            float visibleWidth = SScreenConstants.DEFAULT_SCREEN_WIDTH;
+            float visibleHeight = SScreenConstants.DEFAULT_SCREEN_HEIGHT;
+
+            float worldLeftLimit = 0f;
+            float worldRightLimit = totalWorldWidth - visibleWidth;
+
+            float worldBottomLimit = (totalWorldHeight - visibleHeight) * -1;
+            float worldTopLimit = 0f;
+
+            Vector2 cameraPosition = this._cameraManager.Position;
+
+            cameraPosition.X = MathHelper.Clamp(cameraPosition.X, worldLeftLimit, worldRightLimit);
+            cameraPosition.Y = MathHelper.Clamp(cameraPosition.Y, worldBottomLimit, worldTopLimit);
+
+            this._cameraManager.Position = cameraPosition;
         }
     }
 }

--- a/src/SS.Core/Managers/SGameInputManager.cs
+++ b/src/SS.Core/Managers/SGameInputManager.cs
@@ -4,7 +4,6 @@ using StardustSandbox.Core.Constants;
 using StardustSandbox.Core.InputSystem;
 using StardustSandbox.Core.Interfaces.General;
 using StardustSandbox.Core.Items;
-using StardustSandbox.Core.Managers;
 using StardustSandbox.Core.Objects;
 using StardustSandbox.Core.World;
 

--- a/src/SS.Core/Managers/SGraphicsManager.cs
+++ b/src/SS.Core/Managers/SGraphicsManager.cs
@@ -62,5 +62,13 @@ namespace StardustSandbox.Core.Managers
             this._graphicsDeviceManager.GraphicsProfile = GraphicsProfile.HiDef;
             this._graphicsDeviceManager.ApplyChanges();
         }
+
+        public Vector2 GetScreenScaleFactor()
+        {
+            return new(
+                this._graphicsDeviceManager.PreferredBackBufferWidth / (float)SScreenConstants.DEFAULT_SCREEN_WIDTH,
+                this._graphicsDeviceManager.PreferredBackBufferHeight / (float)SScreenConstants.DEFAULT_SCREEN_HEIGHT
+            );
+        }
     }
 }

--- a/src/SS.Core/Managers/SGraphicsManager.cs
+++ b/src/SS.Core/Managers/SGraphicsManager.cs
@@ -4,8 +4,12 @@ using Microsoft.Xna.Framework.Graphics;
 using StardustSandbox.Core.Constants;
 using StardustSandbox.Core.Interfaces.General;
 using StardustSandbox.Core.IO;
+using StardustSandbox.Core.Mathematics.Primitives;
 using StardustSandbox.Core.Models.Settings;
 using StardustSandbox.Core.Objects;
+
+using System.Linq;
+using System.Windows.Forms;
 
 namespace StardustSandbox.Core.Managers
 {
@@ -54,7 +58,6 @@ namespace StardustSandbox.Core.Managers
         public void UpdateSettings()
         {
             SGraphicsSettings graphicsSettings = SSystemSettingsFile.GetGraphicsSettings();
-
             this._graphicsDeviceManager.IsFullScreen = graphicsSettings.FullScreen;
             this._graphicsDeviceManager.PreferredBackBufferWidth = graphicsSettings.ScreenWidth;
             this._graphicsDeviceManager.PreferredBackBufferHeight = graphicsSettings.ScreenHeight;

--- a/src/SS.Core/Managers/SInputManager.cs
+++ b/src/SS.Core/Managers/SInputManager.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
 
+using StardustSandbox.Core.Constants;
 using StardustSandbox.Core.Interfaces.General;
 using StardustSandbox.Core.Objects;
 
@@ -27,9 +28,28 @@ namespace StardustSandbox.Core.Managers
             this._keyboardState = Keyboard.GetState();
         }
 
+        public Vector2 GetScaledMousePosition()
+        {
+            return CalculateScaledMousePosition(this._mouseState, this.SGameInstance.GraphicsManager);
+        }
+
+        public Vector2 GetScaledPreviousMousePosition()
+        {
+            return CalculateScaledMousePosition(this._previousMouseState, this.SGameInstance.GraphicsManager);
+        }
+
         public int GetDeltaScrollWheel()
         {
             return this._previousMouseState.ScrollWheelValue - this._mouseState.ScrollWheelValue;
+        }
+
+        private static Vector2 CalculateScaledMousePosition(MouseState mouseState, SGraphicsManager graphicsManager)
+        {
+            Vector2 mousePosition = new(mouseState.X, mouseState.Y);
+
+            mousePosition /= graphicsManager.GetScreenScaleFactor();
+
+            return mousePosition;
         }
     }
 }

--- a/src/SS.Core/Models/Settings/SGraphicsSettings.cs
+++ b/src/SS.Core/Models/Settings/SGraphicsSettings.cs
@@ -31,7 +31,7 @@ namespace StardustSandbox.Core.Models.Settings
 
         public SGraphicsSettings()
         {
-            SSize2 resolution = SScreenConstants.RESOLUTIONS[3];
+            SSize2 resolution = SScreenConstants.RESOLUTIONS[4];
 
             this.ScreenWidth = (int)resolution.Width;
             this.ScreenHeight = (int)resolution.Height;

--- a/src/SS.Core/Models/Settings/SGraphicsSettings.cs
+++ b/src/SS.Core/Models/Settings/SGraphicsSettings.cs
@@ -3,6 +3,10 @@
 using StardustSandbox.Core.Constants;
 using StardustSandbox.Core.Mathematics.Primitives;
 
+using System;
+using System.Linq;
+using System.Windows.Forms;
+
 namespace StardustSandbox.Core.Models.Settings
 {
     [MessagePackObject]
@@ -31,15 +35,38 @@ namespace StardustSandbox.Core.Models.Settings
 
         public SGraphicsSettings()
         {
-            SSize2 resolution = SScreenConstants.RESOLUTIONS[4];
+            SSize2 monitorResolution = GetMonitorResolution();
+            SSize2 autoResolution = GetAutoResolution(monitorResolution);
 
-            this.ScreenWidth = (int)resolution.Width;
-            this.ScreenHeight = (int)resolution.Height;
-            this.Resizable = false;
+            this.ScreenWidth = (int)autoResolution.Width;
+            this.ScreenHeight = (int)autoResolution.Height;
+            this.Resizable = true;
             this.FullScreen = false;
             this.Framerate = 60f;
             this.VSync = false;
             this.Borderless = false;
+        }
+        
+        private static SSize2 GetAutoResolution(SSize2 monitorResolution)
+        {
+            for (int i = SScreenConstants.RESOLUTIONS.Length - 1; i >= 0; i--)
+            {
+                SSize2 resolution = SScreenConstants.RESOLUTIONS[i];
+
+                if (resolution.Width <= monitorResolution.Width && resolution.Height <= monitorResolution.Height)
+                {
+                    return resolution;
+                }
+            }
+
+            return SScreenConstants.RESOLUTIONS[0];
+        }
+
+        private static SSize2 GetMonitorResolution()
+        {
+            int width = Screen.PrimaryScreen.Bounds.Width;
+            int height = Screen.PrimaryScreen.Bounds.Height;
+            return new SSize2(width, height);
         }
     }
 }

--- a/src/SS.Core/SGame.Events.cs
+++ b/src/SS.Core/SGame.Events.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.Xna.Framework;
+
+using System;
+
+namespace StardustSandbox.Core
+{
+    public sealed partial class SGame
+    {
+        // Event occurs when the game window returns to focus.
+        protected override void OnActivated(object sender, EventArgs args)
+        {
+            base.OnActivated(sender, args);
+            this.isFocused = true;
+        }
+
+        // Event occurs when the game window stops having focus.
+        protected override void OnDeactivated(object sender, EventArgs args)
+        {
+            base.OnDeactivated(sender, args);
+            this.isFocused = false;
+        }
+
+        // Event occurs when the game process is finished.
+        protected override void OnExiting(object sender, ExitingEventArgs args)
+        {
+            base.OnExiting(sender, args);
+        }
+    }
+}

--- a/src/SS.Core/SGame.Rendering.cs
+++ b/src/SS.Core/SGame.Rendering.cs
@@ -51,15 +51,9 @@ namespace StardustSandbox.Core
 
             #region RENDERING (FINAL)
             this.GraphicsDevice.SetRenderTarget(null);
-
-            Vector2 scaleFactor = new(
-                this._graphicsManager.GraphicsDeviceManager.PreferredBackBufferWidth / (float)SScreenConstants.DEFAULT_SCREEN_WIDTH,
-                this._graphicsManager.GraphicsDeviceManager.PreferredBackBufferHeight / (float)SScreenConstants.DEFAULT_SCREEN_HEIGHT
-            );
-
             this.GraphicsDevice.Clear(Color.Black);
             this._sb.Begin(SpriteSortMode.Deferred, BlendState.NonPremultiplied, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullNone, null, null);
-            this._sb.Draw(this._graphicsManager.ScreenRenderTarget, Vector2.Zero, null, Color.White, 0f, Vector2.Zero, scaleFactor, SpriteEffects.None, 0f);
+            this._sb.Draw(this._graphicsManager.ScreenRenderTarget, Vector2.Zero, null, Color.White, 0f, Vector2.Zero, this._graphicsManager.GetScreenScaleFactor(), SpriteEffects.None, 0f);
             this._cursorManager.Draw(gameTime, this._sb);
             this._sb.End();
             #endregion

--- a/src/SS.Core/SGame.Rendering.cs
+++ b/src/SS.Core/SGame.Rendering.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
+using StardustSandbox.Core.Constants;
+
 namespace StardustSandbox.Core
 {
     public sealed partial class SGame
@@ -48,9 +50,13 @@ namespace StardustSandbox.Core
             #endregion
 
             #region RENDERING (FINAL)
-            Vector2 scaleFactor = Vector2.One;
-
             this.GraphicsDevice.SetRenderTarget(null);
+
+            Vector2 scaleFactor = new(
+                this._graphicsManager.GraphicsDeviceManager.PreferredBackBufferWidth / (float)SScreenConstants.DEFAULT_SCREEN_WIDTH,
+                this._graphicsManager.GraphicsDeviceManager.PreferredBackBufferHeight / (float)SScreenConstants.DEFAULT_SCREEN_HEIGHT
+            );
+
             this.GraphicsDevice.Clear(Color.Black);
             this._sb.Begin(SpriteSortMode.Deferred, BlendState.NonPremultiplied, SamplerState.PointClamp, DepthStencilState.Default, RasterizerState.CullNone, null, null);
             this._sb.Draw(this._graphicsManager.ScreenRenderTarget, Vector2.Zero, null, Color.White, 0f, Vector2.Zero, scaleFactor, SpriteEffects.None, 0f);

--- a/src/SS.Core/SGame.Rendering.cs
+++ b/src/SS.Core/SGame.Rendering.cs
@@ -1,8 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
-using StardustSandbox.Core.Constants;
-
 namespace StardustSandbox.Core
 {
     public sealed partial class SGame

--- a/src/SS.Core/SGame.Routine.cs
+++ b/src/SS.Core/SGame.Routine.cs
@@ -14,15 +14,14 @@ namespace StardustSandbox.Core
                 pluginBuilder.Initialize(this, this.Content);
             }
 
-            #region Databases
+            // Databases
             this._assetDatabase.Initialize();
             this._elementDatabase.Initialize();
             this._itemDatabase.Initialize();
             this._guiDatabase.Initialize();
             this._backgroundDatabase.Initialize();
-            #endregion
 
-            #region Managers
+            // Managers
             this._graphicsManager.Initialize();
             this._gameInputManager.Initialize();
             this._shaderManager.Initialize();
@@ -30,11 +29,9 @@ namespace StardustSandbox.Core
             this._guiManager.Initialize();
             this._cursorManager.Initialize();
             this._backgroundManager.Initialize();
-            #endregion
 
-            #region Game
+            // Core
             this._world.Initialize();
-            #endregion
 
             base.Initialize();
         }
@@ -47,11 +44,15 @@ namespace StardustSandbox.Core
         protected override void BeginRun()
         {
             this._guiManager.ShowGUI(SGUIConstants.HUD_NAME);
-            // this._guiManager.ShowGUI(SGUIConstants.ELEMENT_EXPLORER_NAME);
         }
 
         protected override void Update(GameTime gameTime)
         {
+            if (!this.isFocused)
+            {
+                return;
+            }
+
             // Managers
             this._graphicsManager.Update(gameTime);
             this._gameInputManager.Update(gameTime);

--- a/src/SS.Core/SGame.cs
+++ b/src/SS.Core/SGame.cs
@@ -26,6 +26,7 @@ namespace StardustSandbox.Core
         public SInputManager InputManager => this._inputManager;
         public SGameInputManager GameInputManager => this._gameInputManager;
         public SCameraManager CameraManager => this._cameraManager;
+        public SGraphicsManager GraphicsManager => this._graphicsManager;
         public SGUIManager GUIManager => this._guiManager;
 
         public SWorld World => this._world;

--- a/src/SS.Core/SGame.cs
+++ b/src/SS.Core/SGame.cs
@@ -15,7 +15,7 @@ using System.Collections.Generic;
 
 namespace StardustSandbox.Core
 {
-    public sealed partial class SGame : Microsoft.Xna.Framework.Game, ISGame
+    public sealed partial class SGame : Game, ISGame
     {
         public SAssetDatabase AssetDatabase => this._assetDatabase;
         public SElementDatabase ElementDatabase => this._elementDatabase;
@@ -57,6 +57,9 @@ namespace StardustSandbox.Core
 
         // Plugin System
         private readonly List<SPluginBuilder> pluginBuilders = [];
+
+        // Status
+        private bool isFocused;
 
         // ================================= //
 


### PR DESCRIPTION
# Camera Adjustments and Substantial Resolution Changes

## Introduction

This pull request focuses on implementing systematic and pending changes to the camera system while addressing the game’s resolution issues.

## Description

Among the camera changes, the most notable include updates and optimizations to certain methods and the addition of a camera limiter, which restricts movement to the bounds of the world. Another critical change involves the game's resolution system.

Now, regardless of the window size, the game adjusts and renders to cover all necessary surfaces, applying scaling adjustments to various elements, including mouse positioning, which is recalibrated according to the renderer’s scale factor relative to the game’s main window. Although extremely different resolutions may cause minor visual artifacts, the game functions systematically.

Additionally, upon the first launch, the project now includes an automated system that determines the best-fitting 16:9 aspect ratio size for the user's monitor.

## Issues

- Issue 1: #27

## Notes

An important note concerns the zoom system, which was added but subsequently removed in this PR. The `clamp` method conflicts with the zoom system. I haven't yet found a way to limit the camera within the map while accounting for scale changes that affect various elements. All attempts so far have led to frustrating results, prompting me to temporarily remove the zoom system due to my inability to find a mathematical solution for this issue. I plan to revisit this in the future to find a suitable resolution.